### PR TITLE
fixed: category not showing when created without parent

### DIFF
--- a/views/category/partials/form-create.blade.php
+++ b/views/category/partials/form-create.blade.php
@@ -19,7 +19,7 @@
                 <div class="form-group">
                     <label for="category-id">{{ trans_choice('forum::categories.category', 1) }}</label>
                     <select name="category_id" id="category-id" class="form-control">
-                        <option value="">({{ trans('forum::general.none') }})</option>
+                        <option value="0">({{ trans('forum::general.none') }})</option>
                         @include ('forum::category.partials.options')
                     </select>
                 </div>


### PR DESCRIPTION
When you create a category without specifying a parent it is recorded in the database as an empty category_id (not zero). At least that happens in sqllite. Because of that a new category is not visible on the forum.
