### PR TITLE
Add support of Laravel 5.2

### DIFF
--- a/src/ForumFrontendServiceProvider.php
+++ b/src/ForumFrontendServiceProvider.php
@@ -129,8 +129,12 @@ class ForumFrontendServiceProvider extends ServiceProvider
     protected function loadRoutes(Router $router)
     {
         $dir = $this->baseDir;
-        $router->group(['namespace' => $this->namespace, 'as' => 'forum.', 'prefix' => config('forum.routing.root')], function ($r) use ($dir)
-        {
+        $router->group([
+            'namespace' => $this->namespace,
+            'middleware' => config('forum.routing.middleware'),
+            'as' => 'forum.',
+            'prefix' => config('forum.routing.root')
+        ], function ($r) use ($dir) {
             $controllers = config('forum.frontend.controllers');
             require "{$dir}routes.php";
         });


### PR DESCRIPTION
[More details](https://github.com/Riari/laravel-forum/issues/97)

Require: https://github.com/Riari/laravel-forum/pull/98

To support laravel 5.2 in config you can just define middleware:

``` php
'middleware' => 'web',
```
