### PR TITLE
Using config forum.routing.as for API calls

### DIFF
--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -37,7 +37,8 @@ abstract class BaseController extends Controller implements ReceiverContract
      */
     protected function api($route, $parameters = [])
     {
-        return $this->dispatcher->route("forum.api.{$route}", $parameters);
+        $prefix = config('forum.routing.as');
+        return $this->dispatcher->route("{$prefix}.api.{$route}", $parameters);
     }
 
     /**


### PR DESCRIPTION
Looks like the `forum.routing.as` in the config doesn't get used when calling API routes. Found it when trying to use a custom `routing.as` config other than `forum`.

Just added it here so it pulls from the `config('forum.routing.as')`.
