### PR TITLE
Fixed issue with Laravel 5.4 - 5.6 compatability

### DIFF
--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -3,7 +3,7 @@
 use Forum;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;


### PR DESCRIPTION
In Laravel 5.4 the folder is renamed to Exceptions. 

https://github.com/laravel/framework/pull/17398